### PR TITLE
MAID-2904 safe_mobile CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # SAFE Mobile Examples
 
+|CI - Xamarin.Android|
+|:-----------------:|
+|[![Build status](https://ci.appveyor.com/api/projects/status/2fnekwfbm5h2ayk7/branch/master?svg=true)](https://ci.appveyor.com/project/MaidSafe-QA/safe-mobile/branch/master)|
+
 ## Overview
 
 Mobile samples of SAFE Authenticator and SAFE Messages/Mail example.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,21 @@
+environment: 
+  matrix:
+    - solution_name: SafeAuthenticator/SafeAuthenticator.sln
+    - solution_name: SafeMessages/SafeMessages.sln
+
+cache:
+  - '%temp%\nativeauthlibs'
+  - packages -> **\**\packages.config
+  - '%USERPROFILE%\.nuget\packages'
+  - SafeAuthenticator\tools -> SafeAuthenticator\build.cake, SafeAuthenticator\build.ps1, SafeAuthenticator\build.sh
+
+image: Visual Studio 2017
+
+before_build:
+ - cmd : nuget restore %solution_name% -verbosity quiet
+
+build:
+  verbosity: normal
+
+build_script:
+ - msbuild %solution_name%


### PR DESCRIPTION
**Changes**
- Add AppVeyor CI configuration
- Build SafeAuthenticator and SafeMobile for Android (Xamarin.ios not supported by AppVeyor)
- add CI build status in README

***Tests will be added in future PR. Android test run setup for CI will also be added** 