### PR TITLE
Add linter (StyleCop.Analyzers)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,7 +161,6 @@ AppPackages/
 sql/
 *.Cache
 ClientBin/
-[Ss]tyle[Cc]op.*
 ~$*
 *~
 *.dbmdl
@@ -171,6 +170,7 @@ ClientBin/
 node_modules/
 .DS_Store
 *.bak
+.vscode
 
 # RIA/Silverlight projects
 Generated_Code/

--- a/CodeStyles.targets
+++ b/CodeStyles.targets
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project
+    xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)SafeMessages.ruleset</CodeAnalysisRuleSet>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="All" />
+        <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" InProject="false" />
+    </ItemGroup>
+</Project>

--- a/SafeMessages.Android/Helpers/FileOps.cs
+++ b/SafeMessages.Android/Helpers/FileOps.cs
@@ -17,11 +17,8 @@ namespace SafeMessages.Droid.Helpers
         {
             get
             {
-                string path;
-
                 // Personal -> /data/data/@PACKAGE_NAME@/files
-                path = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
-                return path;
+                return Environment.GetFolderPath(Environment.SpecialFolder.Personal);
             }
         }
 

--- a/SafeMessages.Android/Helpers/FileOps.cs
+++ b/SafeMessages.Android/Helpers/FileOps.cs
@@ -18,6 +18,7 @@ namespace SafeMessages.Droid.Helpers
             get
             {
                 string path;
+
                 // Personal -> /data/data/@PACKAGE_NAME@/files
                 path = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
                 return path;
@@ -27,6 +28,7 @@ namespace SafeMessages.Droid.Helpers
         public async Task TransferAssetsAsync(List<(string, string)> fileList)
         {
             foreach (var tuple in fileList)
+            {
                 using (var reader = new StreamReader(Application.Context.Assets.Open(tuple.Item1)))
                 {
                     using (var writer = new StreamWriter(Path.Combine(ConfigFilesPath, tuple.Item2)))
@@ -37,6 +39,7 @@ namespace SafeMessages.Droid.Helpers
 
                     reader.Close();
                 }
+            }
         }
     }
 }

--- a/SafeMessages.Android/MainActivity.cs
+++ b/SafeMessages.Android/MainActivity.cs
@@ -22,36 +22,37 @@ namespace SafeMessages.Droid
         LaunchMode = LaunchMode.SingleTask,
         ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation)]
     [IntentFilter(
-        new[] {Intent.ActionView},
-        Categories = new[] {Intent.CategoryDefault, Intent.CategoryBrowsable},
+        new[] { Intent.ActionView },
+        Categories = new[] { Intent.CategoryDefault, Intent.CategoryBrowsable },
         DataScheme = AppService.AppId)]
     public class MainActivity : FormsAppCompatActivity
     {
-        private AppService SafeApp => DependencyService.Get<AppService>();
         private static string LogFolderPath => DependencyService.Get<IFileOps>().ConfigFilesPath;
+
+        private AppService SafeApp => DependencyService.Get<AppService>();
 
         private void HandleAppLaunch(string url)
         {
             Debug.WriteLine($"Launched via: {url}");
-            Device.BeginInvokeOnMainThread(
-                async () =>
+            Device.BeginInvokeOnMainThread(async () =>
+            {
+                try
                 {
-                    try
-                    {
-                        await SafeApp.HandleUrlActivationAsync(url);
-                        Debug.WriteLine("IPC Msg Handling Completed");
-                    }
-                    catch (Exception ex)
-                    {
-                        Debug.WriteLine($"Error: {ex.Message}");
-                    }
-                });
+                    await SafeApp.HandleUrlActivationAsync(url);
+                    Debug.WriteLine("IPC Msg Handling Completed");
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine($"Error: {ex.Message}");
+                }
+            });
         }
 
         public override void OnBackPressed()
         {
             if (Xamarin.Forms.Application.Current.MainPage is NavigationPage currentNav &&
-                currentNav.Navigation.NavigationStack.Count == 1) SafeApp.FreeState();
+                currentNav.Navigation.NavigationStack.Count == 1)
+                SafeApp.FreeState();
 
             base.OnBackPressed();
         }
@@ -73,13 +74,15 @@ namespace SafeMessages.Droid
             UserDialogs.Init(this);
             LoadApplication(new App());
 
-            if (Intent?.Data != null) HandleAppLaunch(Intent.Data.ToString());
+            if (Intent?.Data != null)
+                HandleAppLaunch(Intent.Data.ToString());
         }
 
         protected override void OnNewIntent(Intent intent)
         {
             base.OnNewIntent(intent);
-            if (intent?.Data != null) HandleAppLaunch(intent.Data.ToString());
+            if (intent?.Data != null)
+                HandleAppLaunch(intent.Data.ToString());
         }
 
         #region Error Handling
@@ -90,8 +93,7 @@ namespace SafeMessages.Droid
             LogUnhandledException(newExc);
         }
 
-        private static void TaskSchedulerOnUnobservedTaskException(object sender,
-            UnobservedTaskExceptionEventArgs exEventArgs)
+        private static void TaskSchedulerOnUnobservedTaskException(object sender, UnobservedTaskExceptionEventArgs exEventArgs)
         {
             var newExc = new Exception("TaskSchedulerOnUnobservedTaskException", exEventArgs.Exception);
             LogUnhandledException(newExc);
@@ -123,7 +125,8 @@ namespace SafeMessages.Droid
             const string errorFilename = "Fatal.log";
             var errorFilePath = Path.Combine(LogFolderPath, errorFilename);
 
-            if (!File.Exists(errorFilePath)) return;
+            if (!File.Exists(errorFilePath))
+                return;
 
             var errorText = File.ReadAllText(errorFilePath);
             new AlertDialog.Builder(this).SetPositiveButton("Clear", (sender, args) => { File.Delete(errorFilePath); })

--- a/SafeMessages.Android/Properties/AssemblyInfo.cs
+++ b/SafeMessages.Android/Properties/AssemblyInfo.cs
@@ -21,5 +21,5 @@
 // The following attributes are used to specify the signing key for the assembly,
 // if desired. See the Mono documentation for more information about signing.
 
-//[assembly: AssemblyDelaySign(false)]
-//[assembly: AssemblyKeyFile("")]
+// [assembly: AssemblyDelaySign(false)]
+// [assembly: AssemblyKeyFile("")]

--- a/SafeMessages.Android/SafeMessages.Android.csproj
+++ b/SafeMessages.Android/SafeMessages.Android.csproj
@@ -207,4 +207,8 @@
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
   <Import Project="..\..\packages\Xamarin.Android.Support.Animated.Vector.Drawable.25.4.0.2\build\MonoAndroid70\Xamarin.Android.Support.Animated.Vector.Drawable.targets" Condition="Exists('..\..\packages\Xamarin.Android.Support.Animated.Vector.Drawable.25.4.0.2\build\MonoAndroid70\Xamarin.Android.Support.Animated.Vector.Drawable.targets')" />
+  <Import Project="$(MSBuildThisFileDirectory)..\CodeStyles.targets" />
+  <ItemGroup>
+    <Content Include="..\stylecop.json" Link="stylecop.json" />
+  </ItemGroup>
 </Project>

--- a/SafeMessages.iOS/AppDelegate.cs
+++ b/SafeMessages.iOS/AppDelegate.cs
@@ -15,6 +15,7 @@ namespace SafeMessages.iOS
     public class AppDelegate : FormsApplicationDelegate
     {
         public AppService SafeApp => DependencyService.Get<AppService>();
+
         private static string LogFolderPath => DependencyService.Get<IFileOps>().ConfigFilesPath;
 
         public override bool FinishedLaunching(UIApplication app, NSDictionary options)
@@ -50,8 +51,7 @@ namespace SafeMessages.iOS
 
         #region Error Handling
 
-        private static void TaskSchedulerOnUnobservedTaskException(object sender,
-            UnobservedTaskExceptionEventArgs exEventArgs)
+        private static void TaskSchedulerOnUnobservedTaskException(object sender, UnobservedTaskExceptionEventArgs exEventArgs)
         {
             var newExc = new Exception("TaskSchedulerOnUnobservedTaskException", exEventArgs.Exception);
             LogUnhandledException(newExc);
@@ -83,20 +83,20 @@ namespace SafeMessages.iOS
             const string errorFilename = "Fatal.log";
             var errorFilePath = Path.Combine(LogFolderPath, errorFilename);
 
-            if (!File.Exists(errorFilePath)) return;
+            if (!File.Exists(errorFilePath))
+                return;
 
             var errorText = File.ReadAllText(errorFilePath);
-            Device.BeginInvokeOnMainThread(
-                () =>
-                {
-                    var vc = UIApplication.SharedApplication?.KeyWindow?.RootViewController;
-                    if (vc == null) return;
-                    var alert = UIAlertController.Create("Crash Report", errorText, UIAlertControllerStyle.Alert);
-                    alert.AddAction(UIAlertAction.Create("Close", UIAlertActionStyle.Cancel, null));
-                    alert.AddAction(UIAlertAction.Create("Clear", UIAlertActionStyle.Default,
-                        action => { File.Delete(errorFilePath); }));
-                    vc.PresentViewController(alert, true, null);
-                });
+            Device.BeginInvokeOnMainThread(() =>
+            {
+                var vc = UIApplication.SharedApplication?.KeyWindow?.RootViewController;
+                if (vc == null)
+                    return;
+                var alert = UIAlertController.Create("Crash Report", errorText, UIAlertControllerStyle.Alert);
+                alert.AddAction(UIAlertAction.Create("Close", UIAlertActionStyle.Cancel, null));
+                alert.AddAction(UIAlertAction.Create("Clear", UIAlertActionStyle.Default, action => { File.Delete(errorFilePath); }));
+                vc.PresentViewController(alert, true, null);
+            });
         }
 
         #endregion

--- a/SafeMessages.iOS/GlobalSuppressions.cs
+++ b/SafeMessages.iOS/GlobalSuppressions.cs
@@ -1,0 +1,7 @@
+﻿// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:Element should begin with upper-case letter", Justification = "default iOS namespace", Scope = "namespace", Target = "~N:SafeMessages.iOS.Helpers")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:Element should begin with upper-case letter", Justification = "default iOS namespace", Scope = "namespace", Target = "~N:SafeMessages.iOS")]

--- a/SafeMessages.iOS/Helpers/FileOps.cs
+++ b/SafeMessages.iOS/Helpers/FileOps.cs
@@ -16,11 +16,8 @@ namespace SafeMessages.iOS.Helpers
         {
             get
             {
-                string path;
-
                 // Resources -> /Library
-                path = Environment.GetFolderPath(Environment.SpecialFolder.Resources);
-                return path;
+                return Environment.GetFolderPath(Environment.SpecialFolder.Resources);
             }
         }
 

--- a/SafeMessages.iOS/Helpers/FileOps.cs
+++ b/SafeMessages.iOS/Helpers/FileOps.cs
@@ -17,7 +17,8 @@ namespace SafeMessages.iOS.Helpers
             get
             {
                 string path;
-// Resources -> /Library
+
+                // Resources -> /Library
                 path = Environment.GetFolderPath(Environment.SpecialFolder.Resources);
                 return path;
             }
@@ -26,6 +27,7 @@ namespace SafeMessages.iOS.Helpers
         public async Task TransferAssetsAsync(List<(string, string)> fileList)
         {
             foreach (var tuple in fileList)
+            {
                 using (var reader = new StreamReader(Path.Combine(".", tuple.Item1)))
                 {
                     using (var writer = new StreamWriter(Path.Combine(ConfigFilesPath, tuple.Item2)))
@@ -36,6 +38,7 @@ namespace SafeMessages.iOS.Helpers
 
                     reader.Close();
                 }
+            }
         }
     }
 }

--- a/SafeMessages.iOS/SafeMessages.iOS.csproj
+++ b/SafeMessages.iOS/SafeMessages.iOS.csproj
@@ -126,6 +126,7 @@
     <None Include="Entitlements.plist" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="Helpers\FileOps.cs" />
     <Compile Include="Main.cs" />
     <Compile Include="AppDelegate.cs" />
@@ -208,4 +209,8 @@
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)..\CodeStyles.targets" />
+  <ItemGroup>
+    <Content Include="..\stylecop.json" Link="stylecop.json" />
+  </ItemGroup>
 </Project>

--- a/SafeMessages.ruleset
+++ b/SafeMessages.ruleset
@@ -1,0 +1,219 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Rules for SafeAuthenticator" Description="Code analysis rules for SafeAuthenticator." ToolsVersion="15.0">
+  <IncludeAll Action="Warning" />
+  <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <!--
+      =================================================================================================================
+      Following rule actions are overriden to None for this ruleset
+      SA1600: A C# code element is missing a documentation header.
+      SA1309: A field name in C# begins with an underscore.
+      SA1124: The C# code contains a region.
+      =================================================================================================================
+    -->
+    <Rule Id="SA0001" Action="None" />
+    <Rule Id="SA0002" Action="Warning" />
+    <Rule Id="SA1000" Action="Warning" />
+    <Rule Id="SA1001" Action="Warning" />
+    <Rule Id="SA1002" Action="Warning" />
+    <Rule Id="SA1003" Action="Warning" />
+    <Rule Id="SA1004" Action="Warning" />
+    <Rule Id="SA1005" Action="Warning" />
+    <Rule Id="SA1006" Action="Warning" />
+    <Rule Id="SA1007" Action="Warning" />
+    <Rule Id="SA1008" Action="Warning" />
+    <Rule Id="SA1009" Action="Warning" />
+    <Rule Id="SA1010" Action="Warning" />
+    <Rule Id="SA1011" Action="Warning" />
+    <Rule Id="SA1012" Action="Warning" />
+    <Rule Id="SA1013" Action="Warning" />
+    <Rule Id="SA1014" Action="Warning" />
+    <Rule Id="SA1015" Action="Warning" />
+    <Rule Id="SA1016" Action="Warning" />
+    <Rule Id="SA1017" Action="Warning" />
+    <Rule Id="SA1018" Action="Warning" />
+    <Rule Id="SA1019" Action="Warning" />
+    <Rule Id="SA1020" Action="Warning" />
+    <Rule Id="SA1021" Action="Warning" />
+    <Rule Id="SA1022" Action="Warning" />
+    <Rule Id="SA1023" Action="Warning" />
+    <Rule Id="SA1024" Action="Warning" />
+    <Rule Id="SA1025" Action="Warning" />
+    <Rule Id="SA1026" Action="Warning" />
+    <Rule Id="SA1027" Action="Warning" />
+    <Rule Id="SA1028" Action="Warning" />
+    <Rule Id="SA1100" Action="Warning" />
+    <Rule Id="SA1101" Action="None" />
+    <Rule Id="SA1102" Action="Warning" />
+    <Rule Id="SA1103" Action="Warning" />
+    <Rule Id="SA1104" Action="Warning" />
+    <Rule Id="SA1105" Action="Warning" />
+    <Rule Id="SA1106" Action="Warning" />
+    <Rule Id="SA1107" Action="Warning" />
+    <Rule Id="SA1108" Action="Warning" />
+    <Rule Id="SA1109" Action="Warning" />
+    <Rule Id="SA1110" Action="Warning" />
+    <Rule Id="SA1111" Action="Warning" />
+    <Rule Id="SA1112" Action="Warning" />
+    <Rule Id="SA1113" Action="Warning" />
+    <Rule Id="SA1114" Action="Warning" />
+    <Rule Id="SA1115" Action="Warning" />
+    <Rule Id="SA1116" Action="Warning" />
+    <Rule Id="SA1117" Action="Warning" />
+    <Rule Id="SA1118" Action="Warning" />
+    <Rule Id="SA1119" Action="Warning" />
+    <Rule Id="SA1120" Action="Warning" />
+    <Rule Id="SA1121" Action="Warning" />
+    <Rule Id="SA1122" Action="Warning" />
+    <Rule Id="SA1123" Action="Warning" />
+    <Rule Id="SA1124" Action="None" />
+    <Rule Id="SA1125" Action="Warning" />
+    <Rule Id="SA1126" Action="Warning" />
+    <Rule Id="SA1127" Action="Warning" />
+    <Rule Id="SA1128" Action="Warning" />
+    <Rule Id="SA1129" Action="Warning" />
+    <Rule Id="SA1130" Action="Warning" />
+    <Rule Id="SA1131" Action="Warning" />
+    <Rule Id="SA1132" Action="Warning" />
+    <Rule Id="SA1133" Action="Warning" />
+    <Rule Id="SA1134" Action="Warning" />
+    <Rule Id="SA1135" Action="Warning" />
+    <Rule Id="SA1136" Action="Warning" />
+    <Rule Id="SA1137" Action="Warning" />
+    <Rule Id="SA1139" Action="Warning" />
+    <Rule Id="SA1200" Action="Warning" />
+    <Rule Id="SA1201" Action="None" />
+    <Rule Id="SA1202" Action="None" />
+    <Rule Id="SA1203" Action="Warning" />
+    <Rule Id="SA1204" Action="Warning" />
+    <Rule Id="SA1205" Action="Warning" />
+    <Rule Id="SA1206" Action="Warning" />
+    <Rule Id="SA1207" Action="Warning" />
+    <Rule Id="SA1208" Action="Warning" />
+    <Rule Id="SA1209" Action="Warning" />
+    <Rule Id="SA1210" Action="Warning" />
+    <Rule Id="SA1211" Action="Warning" />
+    <Rule Id="SA1212" Action="Warning" />
+    <Rule Id="SA1213" Action="Warning" />
+    <Rule Id="SA1214" Action="Warning" />
+    <Rule Id="SA1215" Action="Warning" />
+    <Rule Id="SA1216" Action="Warning" />
+    <Rule Id="SA1217" Action="Warning" />
+    <Rule Id="SA1300" Action="Warning" />
+    <Rule Id="SA1301" Action="Warning" />
+    <Rule Id="SA1302" Action="Warning" />
+    <Rule Id="SA1303" Action="None" />
+    <Rule Id="SA1304" Action="Warning" />
+    <Rule Id="SA1305" Action="None" />
+    <Rule Id="SA1306" Action="Warning" />
+    <Rule Id="SA1307" Action="Warning" />
+    <Rule Id="SA1308" Action="Warning" />
+    <Rule Id="SA1309" Action="None" />
+    <Rule Id="SA1310" Action="Warning" />
+    <Rule Id="SA1311" Action="None" />
+    <Rule Id="SA1312" Action="Warning" />
+    <Rule Id="SA1313" Action="Warning" />
+    <Rule Id="SA1314" Action="Warning" />
+    <Rule Id="SA1400" Action="None" />
+    <Rule Id="SA1401" Action="Warning" />
+    <Rule Id="SA1402" Action="None" />
+    <Rule Id="SA1403" Action="Warning" />
+    <Rule Id="SA1404" Action="Warning" />
+    <Rule Id="SA1405" Action="Warning" />
+    <Rule Id="SA1406" Action="Warning" />
+    <Rule Id="SA1407" Action="Warning" />
+    <Rule Id="SA1408" Action="Warning" />
+    <Rule Id="SA1409" Action="Warning" />
+    <Rule Id="SA1410" Action="Warning" />
+    <Rule Id="SA1411" Action="Warning" />
+    <Rule Id="SA1412" Action="Warning" />
+    <Rule Id="SA1413" Action="None" />
+    <Rule Id="SA1500" Action="Warning" />
+    <Rule Id="SA1501" Action="Warning" />
+    <Rule Id="SA1502" Action="Warning" />
+    <Rule Id="SA1503" Action="None" />
+    <Rule Id="SA1504" Action="Warning" />
+    <Rule Id="SA1505" Action="Warning" />
+    <Rule Id="SA1506" Action="Warning" />
+    <Rule Id="SA1507" Action="Warning" />
+    <Rule Id="SA1508" Action="Warning" />
+    <Rule Id="SA1509" Action="Warning" />
+    <Rule Id="SA1510" Action="Warning" />
+    <Rule Id="SA1511" Action="Warning" />
+    <Rule Id="SA1512" Action="None" />
+    <Rule Id="SA1513" Action="None" />
+    <Rule Id="SA1514" Action="Warning" />
+    <Rule Id="SA1515" Action="Warning" />
+    <Rule Id="SA1516" Action="Warning" />
+    <Rule Id="SA1517" Action="Warning" />
+    <Rule Id="SA1518" Action="Warning" />
+    <Rule Id="SA1519" Action="Warning" />
+    <Rule Id="SA1520" Action="Warning" />
+    <Rule Id="SA1600" Action="None" />
+    <Rule Id="SA1601" Action="None" />
+    <Rule Id="SA1602" Action="None" />
+    <Rule Id="SA1603" Action="None" />
+    <Rule Id="SA1604" Action="None" />
+    <Rule Id="SA1605" Action="None" />
+    <Rule Id="SA1606" Action="None" />
+    <Rule Id="SA1607" Action="None" />
+    <Rule Id="SA1608" Action="None" />
+    <Rule Id="SA1609" Action="None" />
+    <Rule Id="SA1610" Action="None" />
+    <Rule Id="SA1611" Action="None" />
+    <Rule Id="SA1612" Action="None" />
+    <Rule Id="SA1613" Action="None" />
+    <Rule Id="SA1614" Action="None" />
+    <Rule Id="SA1615" Action="None" />
+    <Rule Id="SA1616" Action="None" />
+    <Rule Id="SA1617" Action="None" />
+    <Rule Id="SA1618" Action="None" />
+    <Rule Id="SA1619" Action="None" />
+    <Rule Id="SA1620" Action="None" />
+    <Rule Id="SA1621" Action="None" />
+    <Rule Id="SA1622" Action="None" />
+    <Rule Id="SA1623" Action="None" />
+    <Rule Id="SA1624" Action="None" />
+    <Rule Id="SA1625" Action="None" />
+    <Rule Id="SA1626" Action="Warning" />
+    <Rule Id="SA1627" Action="None" />
+    <Rule Id="SA1628" Action="None" />
+    <Rule Id="SA1629" Action="None" />
+    <Rule Id="SA1630" Action="None" />
+    <Rule Id="SA1631" Action="None" />
+    <Rule Id="SA1632" Action="None" />
+    <Rule Id="SA1633" Action="None" />
+    <Rule Id="SA1634" Action="None" />
+    <Rule Id="SA1635" Action="None" />
+    <Rule Id="SA1636" Action="None" />
+    <Rule Id="SA1637" Action="None" />
+    <Rule Id="SA1638" Action="None" />
+    <Rule Id="SA1639" Action="None" />
+    <Rule Id="SA1640" Action="None" />
+    <Rule Id="SA1641" Action="None" />
+    <Rule Id="SA1642" Action="None" />
+    <Rule Id="SA1643" Action="None" />
+    <Rule Id="SA1644" Action="None" />
+    <Rule Id="SA1645" Action="None" />
+    <Rule Id="SA1646" Action="None" />
+    <Rule Id="SA1647" Action="None" />
+    <Rule Id="SA1648" Action="None" />
+    <Rule Id="SA1649" Action="None" />
+    <Rule Id="SA1650" Action="None" />
+    <Rule Id="SA1651" Action="None" />
+    <Rule Id="SA1652" Action="None" />
+    <Rule Id="SX1101" Action="Warning" />
+    <Rule Id="SX1309" Action="None" />
+    <Rule Id="SX1309S" Action="None" />
+    <Rule Id="xUnit1026" Action="None" />
+    <!--
+      =================================================================================================================
+      Rules that are configured in the stylecop.json file
+      https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/Configuration.md
+      =================================================================================================================
+      SA1200: Using directives must be placed correctly.
+              settings.orderingRules.systemUsingDirectivesFirst
+              settings.orderingRules.usingDirectivesPlacement
+      =================================================================================================================
+    -->
+  </Rules>
+</RuleSet>

--- a/SafeMessages/App.xaml.cs
+++ b/SafeMessages/App.xaml.cs
@@ -15,27 +15,27 @@ namespace SafeMessages
         public const string AppName = "SAFE Messages";
         private static volatile bool _isBackgrounded;
 
-        public App()
-        {
-            InitializeComponent();
-
-            MessagingCenter.Subscribe<AppService>(this, MessengerConstants.ResetAppViews,
-                async _ => { await ResetViews(); });
-            Current.MainPage = new NavigationPage(NewStartupPage());
-        }
-
-        public AppService SafeApp => DependencyService.Get<AppService>();
-
         public static bool IsBackgrounded
         {
             get => _isBackgrounded;
             private set => _isBackgrounded = value;
         }
 
+        public App()
+        {
+            InitializeComponent();
+
+            MessagingCenter.Subscribe<AppService>(this, MessengerConstants.ResetAppViews, async _ => { await ResetViews(); });
+            Current.MainPage = new NavigationPage(NewStartupPage());
+        }
+
+        public AppService SafeApp => DependencyService.Get<AppService>();
+
         public static bool IsPageValid(Page page)
         {
             var navPage = Current.MainPage as NavigationPage;
-            if (navPage == null) return false;
+            if (navPage == null)
+                return false;
 
             var validPage = navPage.Navigation.NavigationStack.FirstOrDefault();
             var checkPage = page.Navigation.NavigationStack.FirstOrDefault();
@@ -66,14 +66,16 @@ namespace SafeMessages
         private static async Task ResetViews()
         {
             var navPage = Current.MainPage as NavigationPage;
-            if (navPage == null) return;
+            if (navPage == null)
+                return;
 
             var navigationController = navPage.Navigation;
             foreach (var page in navigationController.NavigationStack.OfType<ICleanup>())
                 page.MessageCenterUnsubscribe();
 
             var rootPage = navigationController.NavigationStack.FirstOrDefault();
-            if (rootPage == null) return;
+            if (rootPage == null)
+                return;
 
             navigationController.InsertPageBefore(NewStartupPage(), rootPage);
             await navigationController.PopToRootAsync(true);

--- a/SafeMessages/Controls/Converters/InverseBooleanConverter.cs
+++ b/SafeMessages/Controls/Converters/InverseBooleanConverter.cs
@@ -8,8 +8,9 @@ namespace SafeMessages.Controls.Converters
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            if (targetType != typeof(bool)) throw new InvalidOperationException("The target must be a boolean");
-            return !(bool) value;
+            if (targetType != typeof(bool))
+                throw new InvalidOperationException("The target must be a boolean");
+            return !(bool)value;
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)

--- a/SafeMessages/Controls/ItemTappedAttachedProperty.cs
+++ b/SafeMessages/Controls/ItemTappedAttachedProperty.cs
@@ -16,7 +16,7 @@ namespace SafeMessages.Controls
 
         public static ICommand GetItemTapped(BindableObject bindable)
         {
-            return (ICommand) bindable.GetValue(CommandProperty);
+            return (ICommand)bindable.GetValue(CommandProperty);
         }
 
         public static void OnItemTapped(object sender, ItemTappedEventArgs e)
@@ -24,12 +24,14 @@ namespace SafeMessages.Controls
             var control = sender as ListView;
             var command = GetItemTapped(control);
 
-            if (command != null && command.CanExecute(e.Item)) command.Execute(e.Item);
+            if (command != null && command.CanExecute(e.Item))
+                command.Execute(e.Item);
         }
 
         private static void OnItemTappedChanged(BindableObject bindable, object oldValue, object newValue)
         {
-            if (bindable is ListView control) control.ItemTapped += OnItemTapped;
+            if (bindable is ListView control)
+                control.ItemTapped += OnItemTapped;
         }
 
         public static void SetItemTapped(BindableObject bindable, ICommand value)

--- a/SafeMessages/Helpers/IFileOps.cs
+++ b/SafeMessages/Helpers/IFileOps.cs
@@ -6,6 +6,7 @@ namespace SafeMessages.Helpers
     public interface IFileOps
     {
         string ConfigFilesPath { get; }
+
         Task TransferAssetsAsync(List<(string, string)> fileList);
     }
 }

--- a/SafeMessages/Helpers/MessengerConstants.cs
+++ b/SafeMessages/Helpers/MessengerConstants.cs
@@ -2,13 +2,13 @@
 {
     internal class MessengerConstants
     {
-        public static string AuthRequestProgress = "AuthRequestProgress";
-        public static string NavAddIdPage = "NavAddIdPage";
-        public static string NavDisplayMessageView = "NavDisplayMessageView";
-        public static string NavMessagesPage = "NavMessagesPage";
-        public static string NavPreviousPage = "NavPreviousPage";
-        public static string NavSendMessagePage = "NavSendMessagePage";
-        public static string NavUserIdsPage = "NavUserIdsPage";
+        internal static readonly string AuthRequestProgress = "AuthRequestProgress";
+        internal static readonly string NavAddIdPage = "NavAddIdPage";
+        internal static readonly string NavDisplayMessageView = "NavDisplayMessageView";
+        internal static readonly string NavMessagesPage = "NavMessagesPage";
+        internal static readonly string NavPreviousPage = "NavPreviousPage";
+        internal static readonly string NavSendMessagePage = "NavSendMessagePage";
+        internal static readonly string NavUserIdsPage = "NavUserIdsPage";
         internal static readonly string ResetAppViews = "ResetAppViews";
     }
 }

--- a/SafeMessages/Helpers/UrlFormat.cs
+++ b/SafeMessages/Helpers/UrlFormat.cs
@@ -12,7 +12,7 @@ namespace SafeMessages.Helpers
 
         public static string GetRequestData(string url)
         {
-            return new Uri(url).PathAndQuery.Replace("/", "");
+            return new Uri(url).PathAndQuery.Replace("/", string.Empty);
         }
     }
 }

--- a/SafeMessages/Models/BaseModel/ObservableObject.cs
+++ b/SafeMessages/Models/BaseModel/ObservableObject.cs
@@ -34,10 +34,10 @@ namespace SafeMessages.Models.BaseModel
         /// <param name="propertyName">Property name.</param>
         /// <param name="onChanged">On changed.</param>
         /// <typeparam name="T">The 1st type parameter.</typeparam>
-        protected bool SetProperty<T>(ref T backingStore, T value, [CallerMemberName] string propertyName = "",
-            Action onChanged = null)
+        protected bool SetProperty<T>(ref T backingStore, T value, [CallerMemberName] string propertyName = "", Action onChanged = null)
         {
-            if (EqualityComparer<T>.Default.Equals(backingStore, value)) return false;
+            if (EqualityComparer<T>.Default.Equals(backingStore, value))
+                return false;
 
             backingStore = value;
             onChanged?.Invoke();

--- a/SafeMessages/Models/BaseModel/ObservableRangeCollection.cs
+++ b/SafeMessages/Models/BaseModel/ObservableRangeCollection.cs
@@ -27,23 +27,27 @@ namespace SafeMessages.Models.BaseModel
         /// </summary>
         /// <param name="collection">collection: The collection from which the elements are copied.</param>
         /// <exception cref="System.ArgumentNullException">The collection parameter cannot be null.</exception>
-        public ObservableRangeCollection(IEnumerable<T> collection) : base(collection)
+        public ObservableRangeCollection(IEnumerable<T> collection)
+            : base(collection)
         {
         }
 
         /// <summary>
         ///     Adds the elements of the specified collection to the end of the ObservableCollection(Of T).
         /// </summary>
-        public void AddRange(IEnumerable<T> collection,
+        public void AddRange(
+            IEnumerable<T> collection,
             NotifyCollectionChangedAction notificationMode = NotifyCollectionChangedAction.Add)
         {
-            if (collection == null) throw new ArgumentNullException(nameof(collection));
+            if (collection == null)
+                throw new ArgumentNullException(nameof(collection));
 
             CheckReentrancy();
 
             if (notificationMode == NotifyCollectionChangedAction.Reset)
             {
-                foreach (var i in collection) Items.Add(i);
+                foreach (var i in collection)
+                    Items.Add(i);
 
                 OnPropertyChanged(new PropertyChangedEventArgs("Count"));
                 OnPropertyChanged(new PropertyChangedEventArgs("Item[]"));
@@ -54,12 +58,12 @@ namespace SafeMessages.Models.BaseModel
 
             var startIndex = Count;
             var changedItems = collection is List<T> list ? list : new List<T>(collection);
-            foreach (var i in changedItems) Items.Add(i);
+            foreach (var i in changedItems)
+                Items.Add(i);
 
             OnPropertyChanged(new PropertyChangedEventArgs("Count"));
             OnPropertyChanged(new PropertyChangedEventArgs("Item[]"));
-            OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, changedItems,
-                startIndex));
+            OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, changedItems, startIndex));
         }
 
         /// <summary>
@@ -67,9 +71,11 @@ namespace SafeMessages.Models.BaseModel
         /// </summary>
         public void RemoveRange(IEnumerable<T> collection)
         {
-            if (collection == null) throw new ArgumentNullException(nameof(collection));
+            if (collection == null)
+                throw new ArgumentNullException(nameof(collection));
 
-            foreach (var i in collection) Items.Remove(i);
+            foreach (var i in collection)
+                Items.Remove(i);
             OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
         }
 
@@ -78,7 +84,7 @@ namespace SafeMessages.Models.BaseModel
         /// </summary>
         public void Replace(T item)
         {
-            ReplaceRange(new[] {item});
+            ReplaceRange(new[] { item });
         }
 
         /// <summary>
@@ -86,7 +92,8 @@ namespace SafeMessages.Models.BaseModel
         /// </summary>
         private void ReplaceRange(IEnumerable<T> collection)
         {
-            if (collection == null) throw new ArgumentNullException(nameof(collection));
+            if (collection == null)
+                throw new ArgumentNullException(nameof(collection));
 
             Items.Clear();
             AddRange(collection, NotifyCollectionChangedAction.Reset);
@@ -95,11 +102,14 @@ namespace SafeMessages.Models.BaseModel
         public void Sort(bool reverse = false)
         {
             var sorted = Items.OrderBy(x => x).ToList();
-            if (reverse) sorted.Reverse();
+            if (reverse)
+                sorted.Reverse();
 
-            if (sorted.Equals(Items)) return;
+            if (sorted.Equals(Items))
+                return;
 
-            for (var i = 0; i < sorted.Count; i++) MoveItem(Items.IndexOf(sorted[i]), i);
+            for (var i = 0; i < sorted.Count; i++)
+                MoveItem(Items.IndexOf(sorted[i]), i);
         }
     }
 }

--- a/SafeMessages/Models/DataModel.cs
+++ b/SafeMessages/Models/DataModel.cs
@@ -15,6 +15,7 @@ namespace SafeMessages.Models
         }
 
         public ObservableRangeCollection<UserId> Accounts { get; set; }
+
         public ObservableRangeCollection<Message> Messages { get; set; }
 
         public void ClearMessages()

--- a/SafeMessages/Models/Message.cs
+++ b/SafeMessages/Models/Message.cs
@@ -13,20 +13,26 @@ namespace SafeMessages.Models
             Body = body;
         }
 
-        [JsonProperty("from")] public string From { get; }
+        [JsonProperty("from")]
+        public string From { get; }
 
-        [JsonProperty("subject")] public string Subject { get; }
+        [JsonProperty("subject")]
+        public string Subject { get; }
 
-        [JsonProperty("time")] public string Time { get; }
+        [JsonProperty("time")]
+        public string Time { get; }
 
-        [JsonProperty("body")] public string Body { get; }
+        [JsonProperty("body")]
+        public string Body { get; }
 
-        [JsonIgnore] public string LocalTime => Convert.ToDateTime(Time).ToString("f");
+        [JsonIgnore]
+        public string LocalTime => Convert.ToDateTime(Time).ToString("f");
 
         public int CompareTo(object obj)
         {
             var other = obj as Message;
-            if (other == null) throw new NotSupportedException();
+            if (other == null)
+                throw new NotSupportedException();
 
             var thisDt = Convert.ToDateTime(Time);
             var otherDt = Convert.ToDateTime(other.Time);
@@ -35,9 +41,11 @@ namespace SafeMessages.Models
 
         public bool Equals(Message other)
         {
-            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(null, other))
+                return false;
 
-            if (ReferenceEquals(this, other)) return true;
+            if (ReferenceEquals(this, other))
+                return true;
 
             return string.Equals(From, other.From) && string.Equals(Subject, other.Subject) &&
                    string.Equals(Time, other.Time) &&
@@ -46,11 +54,13 @@ namespace SafeMessages.Models
 
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(null, obj))
+                return false;
 
-            if (ReferenceEquals(this, obj)) return true;
+            if (ReferenceEquals(this, obj))
+                return true;
 
-            return obj.GetType() == GetType() && Equals((Message) obj);
+            return obj.GetType() == GetType() && Equals((Message)obj);
         }
 
         public override int GetHashCode()

--- a/SafeMessages/Models/MessageBox.cs
+++ b/SafeMessages/Models/MessageBox.cs
@@ -5,21 +5,28 @@ namespace SafeMessages.Models
 {
     public struct DataArray
     {
-        [JsonProperty("type")] public string Type { get; set; }
+        [JsonProperty("type")]
+        public string Type { get; set; }
 
-        [JsonProperty("data")] public List<byte> Data { get; set; }
+        [JsonProperty("data")]
+        public List<byte> Data { get; set; }
     }
 
     public class MessageBox
     {
-        [JsonProperty("email_id")] public string EmailId { get; set; }
+        [JsonProperty("email_id")]
+        public string EmailId { get; set; }
 
-        [JsonProperty("inbox")] public DataArray Inbox { get; set; }
+        [JsonProperty("inbox")]
+        public DataArray Inbox { get; set; }
 
-        [JsonProperty("archive")] public DataArray Archive { get; set; }
+        [JsonProperty("archive")]
+        public DataArray Archive { get; set; }
 
-        [JsonProperty("email_enc_sk")] public string EmailEncSk { get; set; }
+        [JsonProperty("email_enc_sk")]
+        public string EmailEncSk { get; set; }
 
-        [JsonProperty("email_enc_pk")] public string EmailEncPk { get; set; }
+        [JsonProperty("email_enc_pk")]
+        public string EmailEncPk { get; set; }
     }
 }

--- a/SafeMessages/Models/UserId.cs
+++ b/SafeMessages/Models/UserId.cs
@@ -15,22 +15,26 @@ namespace SafeMessages.Models
         public int CompareTo(object obj)
         {
             var other = obj as UserId;
-            if (other == null) throw new NotSupportedException();
+            if (other == null)
+                throw new NotSupportedException();
 
             return string.CompareOrdinal(Name, other.Name);
         }
 
         public bool Equals(UserId other)
         {
-            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(null, other))
+                return false;
             return ReferenceEquals(this, other) || string.Equals(Name, other.Name);
         }
 
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj)) return false;
-            if (ReferenceEquals(this, obj)) return true;
-            return obj.GetType() == GetType() && Equals((UserId) obj);
+            if (ReferenceEquals(null, obj))
+                return false;
+            if (ReferenceEquals(this, obj))
+                return true;
+            return obj.GetType() == GetType() && Equals((UserId)obj);
         }
 
         public override int GetHashCode()

--- a/SafeMessages/SafeMessages.csproj
+++ b/SafeMessages/SafeMessages.csproj
@@ -14,6 +14,11 @@
     <PackageReference Include="Xamarin.Forms" Version="3.3.0.967583" />
   </ItemGroup>
 
+  <Import Project="$(MSBuildThisFileDirectory)..\CodeStyles.targets" />
+  <ItemGroup>
+    <Content Include="..\stylecop.json" Link="stylecop.json" />
+  </ItemGroup>
+
   <ItemGroup>
     <Folder Include="Models\BaseModel\" />
   </ItemGroup>

--- a/SafeMessages/Services/AppService.cs
+++ b/SafeMessages/Services/AppService.cs
@@ -37,6 +37,7 @@ namespace SafeMessages.Services
         }
 
         public UserId Self { get; set; }
+
         private CredentialCacheService CredentialCache { get; }
 
         public bool IsLogInitialised
@@ -57,6 +58,7 @@ namespace SafeMessages.Services
                 var val = Application.Current.Properties[AuthReconnectPropKey] as bool?;
                 return val == true;
             }
+
             set
             {
                 if (value == false)
@@ -120,8 +122,7 @@ namespace SafeMessages.Services
                     var serArchiveMdInfo = await _session.MDataInfoActions.SerialiseAsync(archiveMDataInfoH);
 
                     // Update Inbox permisions to allow anyone to insert
-                    await _session.MDataPermissions.InsertAsync(inboxPermH, NativeHandle.Zero,
-                        new PermissionSet { Insert = true });
+                    await _session.MDataPermissions.InsertAsync(inboxPermH, NativeHandle.Zero, new PermissionSet { Insert = true });
 
                     // Create Inbox MD
                     var (inboxEncPk, inboxEncSk) = await _session.Crypto.EncGenerateKeyPairAsync();
@@ -149,8 +150,7 @@ namespace SafeMessages.Services
                         var pubIdMDataInfoH = new MDataInfo { Name = idDigest.ToArray(), TypeTag = 15001 };
                         using (var pubIdEntriesH = await _session.MDataEntries.NewAsync())
                         {
-                            await _session.MDataEntries.InsertAsync(pubIdEntriesH, "@email".ToUtfBytes(),
-                                serInboxMdInfo);
+                            await _session.MDataEntries.InsertAsync(pubIdEntriesH, "@email".ToUtfBytes(), serInboxMdInfo);
                             await _session.MData.PutAsync(pubIdMDataInfoH, inboxPermH, pubIdEntriesH);
                         }
 
@@ -162,8 +162,7 @@ namespace SafeMessages.Services
                             await _session.MDataInfoActions.EncryptEntryValueAsync(publicNamesContH, idDigest);
                         using (var pubNamesContEntActH = await _session.MDataEntryActions.NewAsync())
                         {
-                            await _session.MDataEntryActions.InsertAsync(pubNamesContEntActH, pubNamesUserIdCipherBytes,
-                                pubNamesMsgBoxCipherBytes);
+                            await _session.MDataEntryActions.InsertAsync(pubNamesContEntActH, pubNamesUserIdCipherBytes, pubNamesMsgBoxCipherBytes);
                             await _session.MData.MutateEntriesAsync(publicNamesContH, pubNamesContEntActH);
                         }
 
@@ -185,8 +184,7 @@ namespace SafeMessages.Services
                             await _session.MDataInfoActions.EncryptEntryValueAsync(appContH, msgBoxSer.ToUtfBytes());
                         using (var appContEntActH = await _session.MDataEntryActions.NewAsync())
                         {
-                            await _session.MDataEntryActions.InsertAsync(appContEntActH, userIdCipherBytes,
-                                msgBoxCipherBytes);
+                            await _session.MDataEntryActions.InsertAsync(appContEntActH, userIdCipherBytes, msgBoxCipherBytes);
                             await _session.MData.MutateEntriesAsync(appContH, appContEntActH);
                         }
                     }
@@ -220,8 +218,7 @@ namespace SafeMessages.Services
                     try
                     {
                         var cts = new CancellationTokenSource(2000);
-                        await UserDialogs.Instance.AlertAsync("Network connection established.", "Success", "OK",
-                            cts.Token);
+                        await UserDialogs.Instance.AlertAsync("Network connection established.", "Success", "OK", cts.Token);
                     }
                     catch (OperationCanceledException)
                     {
@@ -254,9 +251,9 @@ namespace SafeMessages.Services
             var authReq = new AuthReq
             {
                 AppContainer = true,
-                App = new AppExchangeInfo { Id = AppId, Scope = "", Name = "SAFE Messages", Vendor = "MaidSafe.net Ltd" },
+                App = new AppExchangeInfo { Id = AppId, Scope = string.Empty, Name = "SAFE Messages", Vendor = "MaidSafe.net Ltd" },
                 Containers = new List<ContainerPermissions>
-                    {new ContainerPermissions {ContName = "_publicNames", Access = {Insert = true}}}
+                    { new ContainerPermissions { ContName = "_publicNames", Access = { Insert = true } } }
             };
 
             var encodedReq = await Session.EncodeAuthReqAsync(authReq);
@@ -350,6 +347,7 @@ namespace SafeMessages.Services
                 {
                     var ipcMsg = decodeResult as AuthIpcMsg;
                     Debug.WriteLine("Received Auth Granted from Authenticator");
+
                     // update auth progress message
                     MessagingCenter.Send(this, MessengerConstants.AuthRequestProgress, AuthInProgressMessage);
                     if (ipcMsg != null)
@@ -442,8 +440,7 @@ namespace SafeMessages.Services
                     await _session.Crypto.EncryptSealedBoxAsync(encodedString.ToUtfBytes(), dstInboxPkH);
                 using (var dstMsgEntActH = await _session.MDataEntryActions.NewAsync())
                 {
-                    await _session.MDataEntryActions.InsertAsync(dstMsgEntActH,
-                        RandomGenerator.RandomString(15).ToUtfBytes(), msgDataMapNameCipher);
+                    await _session.MDataEntryActions.InsertAsync(dstMsgEntActH, RandomGenerator.RandomString(15).ToUtfBytes(), msgDataMapNameCipher);
                     await _session.MData.MutateEntriesAsync(dstInboxMDataInfoH, dstMsgEntActH);
                 }
             }

--- a/SafeMessages/Services/CredentialCacheService.cs
+++ b/SafeMessages/Services/CredentialCacheService.cs
@@ -1,6 +1,6 @@
 ﻿using System;
-using Xamarin.Essentials;
 using System.Threading.Tasks;
+using Xamarin.Essentials;
 
 namespace SafeMessages.Services
 {

--- a/SafeMessages/ViewModels/AuthViewModel.cs
+++ b/SafeMessages/ViewModels/AuthViewModel.cs
@@ -15,7 +15,8 @@ namespace SafeMessages.ViewModels
         {
             SafeApp.PropertyChanged += (s, e) =>
             {
-                if (e.PropertyName == nameof(SafeApp.IsLogInitialised)) IsUiEnabled = SafeApp.IsLogInitialised;
+                if (e.PropertyName == nameof(SafeApp.IsLogInitialised))
+                    IsUiEnabled = SafeApp.IsLogInitialised;
             };
 
             MessagingCenter.Subscribe<AppService, string>(
@@ -53,7 +54,8 @@ namespace SafeMessages.ViewModels
             get => SafeApp.AuthReconnect;
             set
             {
-                if (SafeApp.AuthReconnect != value) SafeApp.AuthReconnect = value;
+                if (SafeApp.AuthReconnect != value)
+                    SafeApp.AuthReconnect = value;
 
                 OnPropertyChanged();
             }
@@ -70,8 +72,7 @@ namespace SafeMessages.ViewModels
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", $"Generate App Request Failed: {ex.Message}",
-                    "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", $"Generate App Request Failed: {ex.Message}", "OK");
             }
         }
     }

--- a/SafeMessages/ViewModels/MessagesViewModel.cs
+++ b/SafeMessages/ViewModels/MessagesViewModel.cs
@@ -36,7 +36,9 @@ namespace SafeMessages.ViewModels
         }
 
         public ICommand RefreshCommand { get; }
+
         public ICommand SendCommand { get; }
+
         public ICommand MessageSelectedCommand { get; }
 
         private void OnMessageSelectedCommand(Message message)

--- a/SafeMessages/ViewModels/SendMessageViewModel.cs
+++ b/SafeMessages/ViewModels/SendMessageViewModel.cs
@@ -49,12 +49,13 @@ namespace SafeMessages.ViewModels
             IsUiEnabled = false;
             try
             {
-                if (Subject.Length > 150) throw new Exception("Max subject length is 150 characters.");
+                if (Subject.Length > 150)
+                    throw new Exception("Max subject length is 150 characters.");
 
-                if (Body.Length > 150) throw new Exception("Max body length is 150 characters.");
+                if (Body.Length > 150)
+                    throw new Exception("Max body length is 150 characters.");
 
-                await SafeApp.SendMessageAsync(To,
-                    new Message(SafeApp.Self.Name, Subject, DateTime.UtcNow.ToString("r"), Body));
+                await SafeApp.SendMessageAsync(To, new Message(SafeApp.Self.Name, Subject, DateTime.UtcNow.ToString("r"), Body));
                 MessagingCenter.Send(this, MessengerConstants.NavPreviousPage);
             }
             catch (Exception ex)

--- a/SafeMessages/ViewModels/UserIdsViewModel.cs
+++ b/SafeMessages/ViewModels/UserIdsViewModel.cs
@@ -29,7 +29,9 @@ namespace SafeMessages.ViewModels
         }
 
         public ICommand RefreshAccountsCommand { get; }
+
         public ICommand AddAccountCommand { get; }
+
         public ICommand UserIdSelectedCommand { get; }
 
         private void OnAddAccountCommand()

--- a/SafeMessages/Views/AddIdView.xaml.cs
+++ b/SafeMessages/Views/AddIdView.xaml.cs
@@ -17,7 +17,8 @@ namespace SafeMessages.Views
                 async sender =>
                 {
                     MessageCenterUnsubscribe();
-                    if (!App.IsPageValid(this)) return;
+                    if (!App.IsPageValid(this))
+                        return;
 
                     await Navigation.PopAsync();
                 });

--- a/SafeMessages/Views/AuthView.xaml.cs
+++ b/SafeMessages/Views/AuthView.xaml.cs
@@ -17,7 +17,8 @@ namespace SafeMessages.Views
                 async sender =>
                 {
                     MessageCenterUnsubscribe();
-                    if (!App.IsPageValid(this)) return;
+                    if (!App.IsPageValid(this))
+                        return;
 
                     Navigation.InsertPageBefore(new UserIdsView(), this);
                     await Navigation.PopAsync();

--- a/SafeMessages/Views/DisplayMessagePage.xaml.cs
+++ b/SafeMessages/Views/DisplayMessagePage.xaml.cs
@@ -9,7 +9,8 @@ namespace SafeMessages.Views
     [XamlCompilation(XamlCompilationOptions.Compile)]
     public partial class DisplayMessagePage : ContentPage, ICleanup
     {
-        public DisplayMessagePage() : this(null)
+        public DisplayMessagePage()
+            : this(null)
         {
         }
 

--- a/SafeMessages/Views/MessagesView.xaml.cs
+++ b/SafeMessages/Views/MessagesView.xaml.cs
@@ -9,7 +9,8 @@ namespace SafeMessages.Views
     [XamlCompilation(XamlCompilationOptions.Compile)]
     public partial class MessagesView : ContentPage, ICleanup
     {
-        public MessagesView() : this(null)
+        public MessagesView()
+            : this(null)
         {
         }
 
@@ -48,7 +49,8 @@ namespace SafeMessages.Views
                     MessagesListView.SelectedItem = null;
                 });
 
-            if (!viewModel.RefreshCommand.CanExecute(null)) return;
+            if (!viewModel.RefreshCommand.CanExecute(null))
+                return;
 
             AppData.ClearMessages();
             viewModel.RefreshCommand.Execute(null);

--- a/SafeMessages/Views/SendMessageView.xaml.cs
+++ b/SafeMessages/Views/SendMessageView.xaml.cs
@@ -9,7 +9,8 @@ namespace SafeMessages.Views
     [XamlCompilation(XamlCompilationOptions.Compile)]
     public partial class SendMessageView : ContentPage, ICleanup
     {
-        public SendMessageView() : this(null, string.Empty)
+        public SendMessageView()
+            : this(null, string.Empty)
         {
         }
 
@@ -24,7 +25,8 @@ namespace SafeMessages.Views
                 async sender =>
                 {
                     MessageCenterUnsubscribe();
-                    if (!App.IsPageValid(this)) return;
+                    if (!App.IsPageValid(this))
+                        return;
 
                     await Navigation.PopAsync();
                 });

--- a/stylecop.json
+++ b/stylecop.json
@@ -1,0 +1,12 @@
+{
+	"$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
+	"settings": {
+		"layoutRules": {
+			"newlineAtEndOfFile": "require"
+		},
+		"orderingRules": {
+			"systemUsingDirectivesFirst": true,
+			"usingDirectivesPlacement": "outsideNamespace"
+		}
+	}
+}


### PR DESCRIPTION
fixes [#18](https://github.com/maidsafe/safe-email-app-csharp/issues/18)
Changes:
- Add StyleCop.Analyzers nuget package
- Update existing code to follow stylecop
- CI builds are expected to fail if stylecop checks do not pass. Results of failures should be visible in the CI console tab

Rules which are suppressed to priority None.
- SA1309: A field name in C# begins with an underscore.
- SA1124: The C# code contains a region.
- SA1401: (Fields should be private) for some classes (PublicAPI)
- SA1300: Element should begin with upper-case letter (iOS namespace) 